### PR TITLE
Pull Request for Develop Branch

### DIFF
--- a/src/lib/storageServiceWrapper.js
+++ b/src/lib/storageServiceWrapper.js
@@ -1,63 +1,80 @@
 /**
- * StorageService - A helper that saves and loads theme groups 
-   and the active group ID using the browser's storage API.
+ * @fileoverview Storage service wrapper for theme group management
+ * Stores and retrieves serialized theme group objects from browser.storage.local
  */
 
 /**
-
- * @param {Array} groups
- * @returns {Promise}
+ * Saves the provided theme groups to browser storage
+ * @param {Array<Object>} groups - Array of serialized theme group objects
+ * @param {string} groups[].id - Unique group identifier
+ * @param {string} groups[].name - Group display name
+ * @param {Array<string>} groups[].themeIds - Array of theme extension IDs
+ * @returns {Promise<void>} Resolves when groups are saved successfully
+ * @throws {TypeError} If the input is not an array
+ * @throws {Error} If there is an error during the save operation
  */
 async function saveGroups(groups) {
+    if (!Array.isArray(groups)) {
+        throw new TypeError('Invalid input: groups should be an array');
+    }
     try {
         await browser.storage.local.set({ groups: groups });
-        console.log('✅ Groups saved successfully!');
+        console.log('Groups saved successfully');
     } catch (error) {
-        console.error('Oops! Could not save groups:', error);
-        throw error; // Pass the error up so others know too
+        console.error('Could not save groups:', error);
+        throw error;
     }
 }
 
 /**
- * @returns {Promise<Array>}
+ * Loads saved theme groups from browser storage
+ * Returns plain objects, not ThemeGroup instances
+ * @returns {Promise<Array<Object>>} Array of serialized theme group objects (empty if none exist)
+ * @throws {Error} If there is an error during the load operation
  */
 async function loadGroups() {
     try {
         const result = await browser.storage.local.get('groups');
         return result.groups || [];
     } catch (error) {
-        console.error('Oops! Could not load groups:', error);
-        return [];
-    }
-}
-
-/**
-
- * @param {string} id
- * @returns {Promise}
- */
-async function saveActiveGroupId(id) {
-    try {
-        await browser.storage.local.set({ activeGroupId: id });
-        console.log('✅ Active group ID saved:', id);
-    } catch (error) {
-        console.error('Oops! Could not save active group ID:', error);
+        console.error('Could not load groups:', error);
         throw error;
     }
 }
 
 /**
- * @returns {Promise<string|null>}
+ * Saves which group is currently active (selected)
+ * @param {string} id - The ID of the active group to save
+ * @returns {Promise<void>} Resolves when the active group ID is saved successfully
+ * @throws {TypeError} If the input is not a string
+ * @throws {Error} If there is an error during the save operation
+ */
+async function saveActiveGroupId(id) {
+    if (typeof id !== 'string') {
+        throw new TypeError('Invalid input: active group ID should be a string');
+    }
+    try {
+        await browser.storage.local.set({ activeGroupId: id });
+        console.log('Active group ID saved:', id);
+    } catch (error) {
+        console.error('Could not save active group ID:', error);
+        throw error;
+    }
+}
+
+/**
+ * Gets which group is currently active
+ * @returns {Promise<string|null>} The active group ID, or null if not set
+ * @throws {Error} If there is an error during the load operation
  */
 async function loadActiveGroupId() {
     try {
         const result = await browser.storage.local.get('activeGroupId');
         return result.activeGroupId || null;
     } catch (error) {
-        console.error('Oops! Could not load active group ID:', error);
-        return null; // Return null if something breaks
+        console.error('Could not load active group ID:', error);
+        throw error;
     }
 }
 
-// Export so other files can use these helpers
 export { saveGroups, loadGroups, saveActiveGroupId, loadActiveGroupId };

--- a/test/unit/storageServiceWrapper.test.js
+++ b/test/unit/storageServiceWrapper.test.js
@@ -1,0 +1,163 @@
+/**
+ * @fileoverview Unit tests for StorageService module
+ */
+
+// Import the functions to be tested
+import { jest, test } from "@jest/globals";
+import {
+  saveGroups,
+  loadGroups,
+  saveActiveGroupId,
+  loadActiveGroupId,
+} from "../../src/lib/storageServiceWrapper.js";
+
+describe("StorageService", () => {
+  // Mocking the browser.storage API
+  const browserMock = {
+    storage: {
+      local: {
+        get: jest.fn(),
+        set: jest.fn(),
+      },
+    },
+  };
+
+  // Make the mock available globally
+  globalThis.browser = browserMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  beforeAll(() => {
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    console.log.mockRestore();
+    console.error.mockRestore();
+  });
+
+  /* ============================================
+   * GROUP STORAGE TESTS
+   * ============================================ */
+
+  describe("saveGroups", () => {
+    test("should successfully save an array of groups", async () => {
+      const mockGroups = [{ id: "1", name: "Dark Mode" }];
+      browserMock.storage.local.set.mockResolvedValue(undefined);
+
+      await saveGroups(mockGroups);
+
+      expect(browserMock.storage.local.set).toHaveBeenCalledWith({
+        groups: mockGroups,
+      });
+    });
+
+    test("should throw an error if the storage API fails", async () => {
+      const error = new Error("Storage Full");
+      browserMock.storage.local.set.mockRejectedValue(error);
+
+      await expect(saveGroups([])).rejects.toThrow("Storage Full");
+    });
+
+    test("should throw a TypeError if input is not an array", async () => {
+      await expect(saveGroups("not an array")).rejects.toThrow(TypeError);
+    });
+
+    test("should throw a TypeError if input is null", async () => {
+      await expect(saveGroups(null)).rejects.toThrow(TypeError);
+    });
+
+    test("should log success message when groups saved", async () => {
+      browserMock.storage.local.set.mockResolvedValue(undefined);
+      await saveGroups([]);
+      expect(console.log).toHaveBeenCalledWith("Groups saved successfully");
+    });
+  });
+
+  describe("loadGroups", () => {
+    test("should return groups from storage", async () => {
+      const mockGroups = [{ id: "1", name: "Dark Mode" }];
+      browserMock.storage.local.get.mockResolvedValue({ groups: mockGroups });
+
+      const result = await loadGroups();
+
+      expect(result).toEqual(mockGroups);
+      expect(browserMock.storage.local.get).toHaveBeenCalledWith("groups");
+    });
+
+    test("should return an empty array if no groups exist", async () => {
+      browserMock.storage.local.get.mockResolvedValue({});
+
+      const result = await loadGroups();
+
+      expect(result).toEqual([]);
+    });
+
+    test("should throw an error if loading groups fails", async () => {
+      const error = new Error("Read Error");
+      browserMock.storage.local.get.mockRejectedValue(error);
+      await expect(loadGroups()).rejects.toThrow("Read Error");
+    });
+  });
+
+  /* ============================================
+   * ACTIVE GROUP ID TESTS
+   * ============================================ */
+  describe("saveActiveGroupId", () => {
+    test("should successfully save the active group ID", async () => {
+      const id = "group-123";
+      browserMock.storage.local.set.mockResolvedValue(undefined);
+
+      await saveActiveGroupId(id);
+
+      expect(browserMock.storage.local.set).toHaveBeenCalledWith({
+        activeGroupId: id,
+      });
+    });
+
+    test("should throw an error if saving ID fails", async () => {
+      browserMock.storage.local.set.mockRejectedValue(new Error("Write Error"));
+
+      await expect(saveActiveGroupId("123")).rejects.toThrow("Write Error");
+    });
+
+    test("should throw a TypeError if input is not a string", async () => {
+      await expect(saveActiveGroupId(123)).rejects.toThrow(TypeError);
+    });
+
+    test("should throw a TypeError if input is null", async () => {
+      await expect(saveActiveGroupId(null)).rejects.toThrow(TypeError);
+    });
+  });
+
+  describe("loadActiveGroupId", () => {
+    test("should return the active ID from storage", async () => {
+      browserMock.storage.local.get.mockResolvedValue({ activeGroupId: "123" });
+
+      const result = await loadActiveGroupId();
+
+      expect(result).toBe("123");
+      expect(browserMock.storage.local.get).toHaveBeenCalledWith(
+        "activeGroupId",
+      );
+    });
+
+    test("should return null if no active ID is set", async () => {
+      browserMock.storage.local.get.mockResolvedValue({});
+
+      const result = await loadActiveGroupId();
+
+      expect(result).toBeNull();
+    });
+
+    test("should throw an error if loading the ID fails", async () => {
+      const error = new Error("Fatal Error");
+      browserMock.storage.local.get.mockRejectedValue(error);
+
+      await expect(loadActiveGroupId()).rejects.toThrow("Fatal Error");
+    });
+  });
+});


### PR DESCRIPTION
Fix background.js linting errors and test setup
Changes to src/background/background.js:

Fixed import path for storageServiceWrapper from ./storageService.js to ../lib/storageServiceWrapper.js
Renamed instance variable from storageServiceWrapper to storageService to avoid naming conflict with the imported class
Updated all method calls throughout the file to use storageService instead of storageServiceWrapper
Prefixed unused message parameters with _ in GET_ALL_GROUPS, GET_ACTIVE_GROUP, and GET_INSTALLED_THEMES handlers to fix no-unused-vars lint errors
Replaced module.exports with ES module export syntax for compatibility with the project's ES module setup

Changes to test/unit/backrgound.test.js:

Added import { jest } from '@jest/globals' required for ES module mode
Replaced require() with await import() for ES module compatibility
Used jest.unstable_mockModule to properly mock storageServiceWrapper before importing background.js
Set up globalThis.browser before the import to prevent browser is not defined error at load time
Installed cross-env dev dependency to fix cross-env: command not found error when running tests