### PR TITLE
Added group default group initialization on install

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -69,18 +69,14 @@ const messageHandlers = {
    * @returns {Promise<{success: boolean, error: string}>} - Response containing success status
    */
   SAVE_GROUP: async (message) => {
-    const result = manager.updateGroupThemes(
-      message.groupId,
-      message.themes,
-    );
+    const result = manager.updateGroupThemes(message.groupId, message.themes);
     if (!result) {
       return { success: false, error: "Group not found" };
     }
     await manager.save();
     return { success: true };
   },
-  //await manager.Save(): will write to storage asynchronously
-  //
+
   /**
    *
    * @param {Object} message
@@ -95,7 +91,6 @@ const messageHandlers = {
     await manager.save();
     return { success: true };
   },
-  //similar to saveGroup
 
   /**
    *
@@ -109,7 +104,6 @@ const messageHandlers = {
     await manager.save();
     return { success: true };
   },
-  //similar to saveGroup
 
   /**
    *
@@ -218,6 +212,26 @@ function handleMessage(message, sender, sendResponse) {
 // ============================================================================
 // EVENT LISTENERS & INITIALIZATION
 // ============================================================================
+
+/**
+ * Listens for extension installation events to set up default theme groups.
+ * Creates a default group with common themes and sets it as active.
+ *
+ * @param {Object} details - Details about the installation event
+ */
+browser.runtime.onInstalled.addListener((details) => {
+  if (details.reason === "install") {
+    const DEFAULT_THEME_IDS = [
+      "default-theme@mozilla.org",
+      "firefox-compact-light@mozilla.org",
+      "firefox-compact-dark@mozilla.org",
+      "firefox-alpenglow@mozilla.org",
+    ];
+    const defaultGroup = manager.createGroup("Default Group", DEFAULT_THEME_IDS);
+    manager.setActiveGroupId(defaultGroup.id);
+    manager.save();
+  }
+});
 
 browser.runtime.onMessage.addListener(handleMessage);
 

--- a/test/unit/background.test.js
+++ b/test/unit/background.test.js
@@ -3,6 +3,7 @@ import { jest } from '@jest/globals';
 // Mock GroupManager named exports
 const mockManager = {
     initialize: jest.fn(),
+    createGroup: jest.fn(),       // <-- this was missing
     getAllGroups: jest.fn(),
     updateGroupThemes: jest.fn(),
     deleteGroup: jest.fn(),
@@ -30,6 +31,9 @@ globalThis.browser = {
     runtime: {
         onMessage: {
             addListener: jest.fn()
+        },
+        onInstalled: {
+            addListener: jest.fn()
         }
     }
 };
@@ -40,6 +44,7 @@ jest.spyOn(console, 'warn').mockImplementation(() => {});
 jest.spyOn(console, 'error').mockImplementation(() => {});
 
 const { initialize, handleMessage } = await import('../../src/background/background.js');
+const onInstalledListener = browser.runtime.onInstalled.addListener.mock.calls[0][0];
 const { getThemes, getCurrentTheme, enableTheme, disableTheme, getThemeById } = await import('../../src/lib/themeAPI.js');
 
 // Flushes all pending microtasks/promises in the queue.
@@ -49,7 +54,12 @@ const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0));
 
 // Mock console methods to prevent actual logging during tests
 beforeEach(() => {
-    jest.clearAllMocks();
+    // Only clear call history, don't destroy the mock functions
+    Object.values(mockManager).forEach(fn => {
+        if (typeof fn?.mockClear === 'function') {
+            fn.mockClear();
+        }
+    });
     jest.spyOn(console, 'log').mockImplementation(() => {});
     jest.spyOn(console, 'warn').mockImplementation(() => {});
     jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -246,5 +256,35 @@ it('SAVE_GROUP should return error when group not found', async () => {
         handleMessage({ type: 'GET_INSTALLED_THEMES' }, {}, sendResponse);
         await flushPromises();
         expect(sendResponse).toHaveBeenCalledWith({ success: false, error: 'API failure' });
+    });
+});
+
+// ============================================================================
+// EXTENSION INSTALLATION TESTS
+// ============================================================================
+
+describe('Extension Installation', () => {
+    it('should create default group on install', () => {
+        console.log('mockManager keys:', Object.keys(mockManager));
+        console.log('createGroup type:', typeof mockManager.createGroup);
+        console.log('createGroup value:', mockManager.createGroup);
+    });
+
+    it('should create default group on install', () => {
+        mockManager.createGroup.mockReturnValue({ id: 'default-id' });
+        onInstalledListener({ reason: 'install' });
+        expect(mockManager.createGroup).toHaveBeenCalledWith("Default Group", [
+            "default-theme@mozilla.org",
+            "firefox-compact-light@mozilla.org",
+            "firefox-compact-dark@mozilla.org",
+            "firefox-alpenglow@mozilla.org",
+        ]);
+        expect(mockManager.setActiveGroupId).toHaveBeenCalledWith('default-id');
+        expect(mockManager.save).toHaveBeenCalled();
+    });
+
+    it('should not create group on update', () => {
+        onInstalledListener({ reason: 'update' });
+        expect(mockManager.createGroup).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Summary

Adds first-install detection so that new users see a pre-populated "Default Group" containing Firefox's four built-in themes immediately upon opening the extension.

## Changes

### `src/background/background.js`
- Added `browser.runtime.onInstalled` listener that fires on first install (`details.reason === "install"`)
- Creates a "Default Group" with the four built-in Firefox theme IDs
- Sets the new group as the active group and persists to storage

### `test/unit/background.test.js`
- Added `createGroup` to the `mockManager` mock object
- Captured the `onInstalled` listener callback immediately after dynamic import (before `clearAllMocks` can wipe call history)
- Added test: creates default group with correct theme IDs on install
- Added test: does not create a group on extension update

## Default Theme IDs

| Theme      | ID                                  |
|------------|-------------------------------------|
| System     | `default-theme@mozilla.org`         |
| Light      | `firefox-compact-light@mozilla.org` |
| Dark       | `firefox-compact-dark@mozilla.org`  |
| Alpenglow  | `firefox-alpenglow@mozilla.org`     |

## User Story

As a user, when I install the extension for the first time, I want to see a "Default Group" pre-populated with Firefox's four built-in themes so that I have something to interact with immediately.

## Testing Notes

- The `onInstalled` listener registers at module load time, so the test captures the callback reference immediately after the dynamic `import()` and before `beforeEach` resets can clear it
- `createGroup` mock must return an object with an `id` property since `background.js` reads `defaultGroup.id` to set the active group
- Negative case confirms no group creation occurs when `details.reason` is `"update"`
