### PR TITLE
Bugfix/group loading in popup

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -219,7 +219,7 @@ function handleMessage(message, sender, sendResponse) {
  *
  * @param {Object} details - Details about the installation event
  */
-browser.runtime.onInstalled.addListener((details) => {
+browser.runtime.onInstalled.addListener(async (details) => {
   if (details.reason === "install") {
     const DEFAULT_THEME_IDS = [
       "default-theme@mozilla.org",
@@ -229,7 +229,7 @@ browser.runtime.onInstalled.addListener((details) => {
     ];
     const defaultGroup = manager.createGroup("Default Group", DEFAULT_THEME_IDS);
     manager.setActiveGroupId(defaultGroup.id);
-    manager.save();
+    await manager.save();
   }
 });
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,8 +17,9 @@
     ],
 
     "background": {
-        "scripts": ["background.js"],
-        "persistent": true
+        "scripts": ["background/background.js"],
+        "persistent": true,
+        "type": "module"
     },
 
     "browser_action": {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -183,7 +183,7 @@ async function loadPopup() {
     setGroupName(displayName);
 
     renderThemes({
-      themeIds: activeGroup.themeIds || [],
+      themeIds: activeGroup.themes || [],
       installedThemes,
       activeThemeId
     });


### PR DESCRIPTION
##Summary

- Manifest calls background.js and it considers it as a type module
- Popup and background now use the same language when talking about themes in a group
- Background onInstall is now await to allow for proper saving

##Testing

- [x] Default group populates in about:debugging
- [x] All 4 themes are displayed