### PR TITLE
manage group button works onw and once clicked opens the options page

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,6 +15,10 @@
         "management",
         "storage"
     ],
+    "options_ui": {
+        "page": "options/options.html",
+        "open_in_tab": true
+      },
 
     "background": {
         "scripts": ["background/background.js"],
@@ -30,5 +34,6 @@
         "default_title": "ThemeGroups",
         "default_popup": "popup/popup.html"
     }
+    
 
 }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -199,3 +199,6 @@ async function loadPopup() {
  * Initialize popup once DOM is ready.
  */
 document.addEventListener("DOMContentLoaded", loadPopup);
+document.getElementById("manageGroupsBtn").addEventListener("click", () => {
+  browser.runtime.openOptionsPage();
+});


### PR DESCRIPTION
The ManageGroup button on the pop-up works now, and when clicked, redirects you to the options page.